### PR TITLE
Adding Reference to players camera

### DIFF
--- a/Assets/Code/Scripts/Player/Player Stats/PlayerStats.cs
+++ b/Assets/Code/Scripts/Player/Player Stats/PlayerStats.cs
@@ -45,7 +45,7 @@ public class PlayerStats : MonoBehaviour
         _instance = this;
     }
     private void Start()
-    {
+    { //Start does not get called on scriptable objects!
         _instance = this;
         _currentHealth = _maxHealth;
         _currencyCount = 0;

--- a/Assets/Code/Scripts/UI/CameraManager.cs
+++ b/Assets/Code/Scripts/UI/CameraManager.cs
@@ -3,10 +3,21 @@ using UnityEngine;
 
 public class CameraManager : MonoBehaviour
 {
-    private GameObject mPlayer;
+    private static CameraManager _instance;
+    public static CameraManager Instance { get { return _instance; } }
+
+    [SerializeField] private Camera _mainCamera;
+    public Camera MainCamera { get { return _mainCamera; } }
+
     private void Awake()
     {
-        mPlayer = GameObject.FindGameObjectWithTag("Player");
-        gameObject.GetComponentInChildren<CinemachineCamera>().Target.TrackingTarget = mPlayer.transform;
+        if (_instance != null)
+        {
+            Destroy(this);
+            return;
+        }
+        _instance = this;
+
+        gameObject.GetComponentInChildren<CinemachineCamera>().Target.TrackingTarget = PlayerRef.PlayerTransform;
     }
 }

--- a/Assets/Code/Scripts/UI/SpawnsDamagePopups.cs
+++ b/Assets/Code/Scripts/UI/SpawnsDamagePopups.cs
@@ -33,18 +33,8 @@ public class SpawnsDamagePopups : MonoBehaviour
             damageLabel => damageLabel.gameObject.SetActive(true),
             damageLabel => damageLabel.gameObject.SetActive(false)
         );
-        
-        SceneManager.sceneLoaded += OnSceneLoaded;
-    }
 
-    private void OnDestroy()
-    {
-        SceneManager.sceneLoaded -= OnSceneLoaded;
-    }
-
-    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
-    {
-        mainCamera = Camera.main;
+        mainCamera = CameraManager.Instance.MainCamera;
     }
 
     public void DamageDone(float damage, Vector3 position)

--- a/Assets/Level/Prefabs/Items/Finger.prefab
+++ b/Assets/Level/Prefabs/Items/Finger.prefab
@@ -35,6 +35,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6840499159366498734}
+  - {fileID: 1403734110661916966}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2190708703436907014
@@ -249,3 +250,130 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &3126626848573259567
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1403734110661916966}
+  - component: {fileID: 783964859513283734}
+  - component: {fileID: 2060590546708818323}
+  m_Layer: 0
+  m_Name: Point Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1403734110661916966
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3126626848573259567}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.041879952, y: 0.482, z: -0.18481016}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7298120469166719481}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!108 &783964859513283734
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3126626848573259567}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 2
+  m_Color: {r: 1, g: 0.7568628, b: 0.027450982, a: 1}
+  m_Intensity: 0.1
+  m_Range: 1
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!114 &2060590546708818323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3126626848573259567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalLightData
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1

--- a/Assets/Level/Prefabs/Player/PlayerCamera.prefab
+++ b/Assets/Level/Prefabs/Player/PlayerCamera.prefab
@@ -153,6 +153,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 78733e170f94466499b4e9148e0bb237, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CameraManager
+  _mainCamera: {fileID: 7910366510353022445}
 --- !u!1 &8073821831699856941
 GameObject:
   m_ObjectHideFlags: 0
@@ -182,7 +183,7 @@ Transform:
   m_GameObject: {fileID: 8073821831699856941}
   serializedVersion: 2
   m_LocalRotation: {x: 0.30290222, y: -0, z: -0, w: 0.95302165}
-  m_LocalPosition: {x: 5.864079, y: 9.305515, z: -27.599264}
+  m_LocalPosition: {x: -6.1740527, y: 7.0775027, z: -4.533113}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Resources/PERSISTOBJECTS.prefab
+++ b/Assets/Resources/PERSISTOBJECTS.prefab
@@ -29,12 +29,12 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 6895478604575556807}
+  - {fileID: 7885604275273384056}
   - {fileID: 6584047760842748223}
   - {fileID: 4670215584747845809}
   - {fileID: 5034085868764075964}
   - {fileID: 2075662547047845065}
-  - {fileID: 6895478604575556807}
-  - {fileID: 7885604275273384056}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &657610287312959065


### PR DESCRIPTION
It is worth noting that the camera prefab must come before the canvas prefab in the hierarchy of persistent objects. This is so it is loaded, then it gets attached as a reference.